### PR TITLE
Support multiple clients

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -24,6 +24,7 @@ group :development do
 end
 
 group :test do
+  gem 'rails-controller-testing'
   gem 'shoulda'
   gem 'webmock', require: 'webmock/rspec'
   gem 'timecop'

--- a/app/controllers/oauth2_controller.rb
+++ b/app/controllers/oauth2_controller.rb
@@ -5,19 +5,27 @@ require 'login_not_found'
 # @!visibility private
 class Oauth2Controller < ApplicationController
 
+  PASSWORD_PROVIDER_NAME = 'password'.freeze
+  FACEBOOK_PROVIDER_NAME = 'facebook'.freeze
+  GOOGLE_PROVIDER_NAME = 'google'.freeze
+  EDX_PROVIDER_NAME = 'edx'.freeze
+  DEFAULT_CLIENT_NAME = 'unspecified'.freeze
+
   force_ssl if: -> { RailsApiAuth.force_ssl }
 
   # rubocop:disable MethodLength
   def create
+    client = params[:accessing_application] || DEFAULT_CLIENT_NAME
+
     case params[:grant_type]
     when 'password'
-      authenticate_with_credentials(params[:username], params[:password])
+      authenticate_with_credentials(params[:username], params[:password], PASSWORD_PROVIDER_NAME, client)
     when 'facebook_auth_code'
-      authenticate_with_facebook(params[:auth_code])
+      authenticate_with_facebook(params[:auth_code], client)
     when 'google_auth_code'
-      authenticate_with_google(params[:auth_code])
+      authenticate_with_google(params[:auth_code], client)
     when 'edx_auth_code'
-      authenticate_with_edx(params[:username], params[:auth_code])
+      authenticate_with_edx(params[:username], params[:auth_code], client)
     else
       oauth2_error('unsupported_grant_type')
     end
@@ -35,8 +43,13 @@ class Oauth2Controller < ApplicationController
 
   private
 
-    def authenticate_with_credentials(identification, password)
-      login = Login.where(identification: identification).first || LoginNotFound.new
+    def authenticate_with_credentials(identification, password, provider, client)
+      client ||= DEFAULT_CLIENT_NAME  # in case of subclass invocation
+
+      logins = Login.where(identification: identification)
+
+      login = logins.find_by(provider: provider, client: client)
+      login ||= logins.find_by(provider: nil, client: nil) || LoginNotFound.new  # for existing users
 
       if login.authenticate(password)
         render json: { access_token: login.oauth2_token }
@@ -45,21 +58,20 @@ class Oauth2Controller < ApplicationController
       end
     end
 
-    def authenticate_with_facebook(auth_code)
+    def authenticate_with_facebook(auth_code, client)
       oauth2_error('no_authorization_code') && return unless auth_code.present?
 
-      login = FacebookAuthenticator.new(auth_code).authenticate!
+      login = FacebookAuthenticator.new(auth_code, client).authenticate!
 
       render json: { access_token: login.oauth2_token }
     rescue FacebookAuthenticator::ApiError
       render nothing: true, status: 502
     end
 
-    def authenticate_with_google(auth_code)
+    def authenticate_with_google(auth_code, client)
       oauth2_error('no_authorization_code') && return unless auth_code.present?
 
-
-      authenticator = GoogleAuthenticator.new(auth_code)
+      authenticator = GoogleAuthenticator.new(auth_code, client)
       login = authenticator.authenticate!
 
       render json: { access_token: login.oauth2_token }.merge(authenticator.google_user)
@@ -67,11 +79,11 @@ class Oauth2Controller < ApplicationController
       render nothing: true, status: 502
     end
 
-    def authenticate_with_edx(username, auth_code)
+    def authenticate_with_edx(username, auth_code, client)
       oauth2_error('no_authorization_code') && return unless auth_code.present?
       oauth2_error('no_username') && return unless username.present?
 
-      login = EdxAuthenticator.new(username, auth_code).authenticate!
+      login = EdxAuthenticator.new(username, auth_code, client).authenticate!
 
       render json: { access_token: login.oauth2_token }
     rescue EdxAuthenticator::ApiError

--- a/app/models/login.rb
+++ b/app/models/login.rb
@@ -33,7 +33,7 @@ class Login < ActiveRecord::Base
     has_secure_password
   end
 
-  validates :identification, presence: true, uniqueness: true
+  validates :identification, presence: true, uniqueness: { scope: [:provider, :client] }
   validates :oauth2_token, presence: true, uniqueness: true
   validates :single_use_oauth2_token, presence: true, uniqueness: true
   validates :password, length: { maximum: 72 }, confirmation: true

--- a/app/services/edx_authenticator.rb
+++ b/app/services/edx_authenticator.rb
@@ -10,24 +10,16 @@ class EdxAuthenticator < BaseAuthenticator
   TOKEN_URL   = (DOMAIN + '/oauth2/access_token').freeze
   PROFILE_URL = (DOMAIN + '/api/user/v1/accounts/%{username}').freeze
 
-  def initialize(username, auth_code)
+  def initialize(username, auth_code, client)
     @auth_code = auth_code
     @username  = username
+    @client    = client
   end
 
   private
 
-    def connect_login_to_account(login, user)
-      login.update_attributes!(uid: user[:username], provider: PROVIDER)
-    end
-
-    def create_login_from_account(user)
-      login_attributes = {
-        identification: user[:email],
-        uid: user[:username],
-        provider: PROVIDER
-      }
-      Login.create!(login_attributes)
+    def get_uid(user)
+      user[:username]
     end
 
     def access_token

--- a/app/services/facebook_authenticator.rb
+++ b/app/services/facebook_authenticator.rb
@@ -11,18 +11,8 @@ class FacebookAuthenticator < BaseAuthenticator
 
   private
 
-    def connect_login_to_account(login, user)
-      login.update_attributes!(uid: user[:id], provider: PROVIDER)
-    end
-
-    def create_login_from_account(user)
-      login_attributes = {
-        identification: user[:email],
-        uid: user[:id],
-        provider: PROVIDER
-      }
-
-      Login.create!(login_attributes)
+    def get_uid(user)
+      user[:id]
     end
 
     def access_token

--- a/app/services/google_authenticator.rb
+++ b/app/services/google_authenticator.rb
@@ -13,18 +13,8 @@ class GoogleAuthenticator < BaseAuthenticator
 
   private
 
-    def connect_login_to_account(login, user)
-      login.update_attributes!(uid: user[:sub], provider: PROVIDER)
-    end
-
-    def create_login_from_account(user)
-      login_attributes = {
-        identification: user[:email],
-        uid: user[:sub],
-        provider: PROVIDER
-      }
-
-      Login.create!(login_attributes)
+    def get_uid(user)
+      user[:sub]
     end
 
     def access_token

--- a/db/migrate/20400904110441_remove_unique_index_from_identification.rb
+++ b/db/migrate/20400904110441_remove_unique_index_from_identification.rb
@@ -1,0 +1,11 @@
+class RemoveUniqueIndexFromIdentification < ActiveRecord::Migration
+
+  def change
+    # remove previous, unique index
+    remove_index :logins, :identification
+
+    # add new index without uniqueness
+    add_index :logins, :identification
+  end
+
+end

--- a/db/migrate/20400904110442_add_client_to_logins.rb
+++ b/db/migrate/20400904110442_add_client_to_logins.rb
@@ -1,0 +1,7 @@
+class AddClientToLogins < ActiveRecord::Migration
+
+  def change
+    add_column :logins, :client, :string
+  end
+
+end

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -1,4 +1,3 @@
-# encoding: UTF-8
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -11,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20150904110438) do
+ActiveRecord::Schema.define(version: 20400904110442) do
 
   create_table "accounts", force: :cascade do |t|
     t.string   "first_name", null: false
@@ -30,6 +29,8 @@ ActiveRecord::Schema.define(version: 20150904110438) do
     t.datetime "created_at"
     t.datetime "updated_at"
     t.string   "provider"
+    t.string   "client"
+    t.index ["identification"], name: "index_logins_on_identification"
   end
 
 end

--- a/spec/support/shared_examples/authenticator_shared_requests.rb
+++ b/spec/support/shared_examples/authenticator_shared_requests.rb
@@ -1,19 +1,21 @@
 shared_examples 'a authenticator' do
   describe '#authenticate!' do
     let(:login) { double('login') }
+    client = Oauth2Controller::DEFAULT_CLIENT_NAME
 
     if described_class::PROVIDER.eql? 'edx'
-      subject { described_class.new(username, auth_code).authenticate! }
+      subject { described_class.new(username, auth_code, client).authenticate! }
     else
-      subject { described_class.new(auth_code).authenticate! }
+      subject { described_class.new(auth_code, client).authenticate! }
     end
 
     context "when no login for the #{described_class::PROVIDER} account exists" do
       let(:login_attributes) do
         {
+          provider: described_class::PROVIDER,
+          client: client,
           identification: authenticated_user_data[:email],
-          uid: authenticated_user_data[uid_mapped_field.to_sym],
-          provider: described_class::PROVIDER
+          uid: authenticated_user_data[uid_mapped_field.to_sym]
         }
       end
 
@@ -26,14 +28,41 @@ shared_examples 'a authenticator' do
       end
     end
 
-    context "when a login for the #{described_class::PROVIDER} account exists already" do
+    context "when an old login for the #{described_class::PROVIDER} account exists already" do
       before do
-        expect(Login).to receive(:where).with(identification: authenticated_user_data[:email]).and_return([login])
-        allow(login).to receive(:update_attributes!).with(uid: authenticated_user_data[uid_mapped_field.to_sym], provider: described_class::PROVIDER)
+        # an "old" login doesn't have a provider or client
+        expect(Login).to receive(:find_by).with(
+            provider: described_class::PROVIDER,
+            client: client,
+            identification: authenticated_user_data[:email]
+          ).and_return(nil)
+          expect(Login).to receive(:find_by).with(
+              provider: nil,
+              client: nil,
+              identification: authenticated_user_data[:email]
+            ).and_return(login)
+        allow(login).to receive(:update_attributes!).with(uid: authenticated_user_data[uid_mapped_field.to_sym], provider: described_class::PROVIDER, client: client)
       end
 
       it "connects the login to the #{described_class::PROVIDER} account" do
-        expect(login).to receive(:update_attributes!).with(uid: authenticated_user_data[uid_mapped_field.to_sym], provider: described_class::PROVIDER)
+        expect(login).to receive(:update_attributes!).with(uid: authenticated_user_data[uid_mapped_field.to_sym], provider: described_class::PROVIDER, client: client)
+
+        subject
+      end
+    end
+
+    context "when a new login for the #{described_class::PROVIDER} account exists already" do
+      before do
+        expect(Login).to receive(:find_by).with(
+            provider: described_class::PROVIDER,
+            client: client,
+            identification: authenticated_user_data[:email]
+          ).and_return(login)
+        allow(login).to receive(:update_attributes!).with(uid: authenticated_user_data[uid_mapped_field.to_sym], provider: described_class::PROVIDER, client: client)
+      end
+
+      it "connects the login to the #{described_class::PROVIDER} account" do
+        expect(login).to receive(:update_attributes!).with(uid: authenticated_user_data[uid_mapped_field.to_sym], provider: described_class::PROVIDER, client: client)
 
         subject
       end

--- a/spec/support/shared_examples/oauth2_shared_requests.rb
+++ b/spec/support/shared_examples/oauth2_shared_requests.rb
@@ -17,7 +17,16 @@ shared_context 'oauth2 shared contexts' do
 
     it "responds with the login's OAuth 2.0 token" do
       subject
-      expect(response.body).to be_json_eql({ access_token: login.oauth2_token }.to_json)
+
+      if grant_type.eql? 'google_auth_code'
+        expect(response.body).to be_json_eql({
+          access_token: login.oauth2_token,
+          email: email,
+          sub: authenticated_user_data[uid_mapped_field.to_sym]
+        }.to_json)
+      else
+        expect(response.body).to be_json_eql({ access_token: login.oauth2_token }.to_json)
+      end
     end
   end
 
@@ -38,7 +47,15 @@ shared_context 'oauth2 shared contexts' do
       subject
       login = Login.where(identification: email).first
 
-      expect(response.body).to be_json_eql({ access_token: login.oauth2_token }.to_json)
+      if grant_type.eql? 'google_auth_code'
+        expect(response.body).to be_json_eql({
+          access_token: login.oauth2_token,
+          email: email,
+          sub: authenticated_user_data[uid_mapped_field.to_sym]
+        }.to_json)
+      else
+        expect(response.body).to be_json_eql({ access_token: login.oauth2_token }.to_json)
+      end
     end
   end
 


### PR DESCRIPTION
The default behavior of Rails API Auth is to support any number of clients with a single OAuth token. We wanted to make it more secure so we added support for multiple tokens for multiple clients (but still for the same user).
